### PR TITLE
Update default property name casing from snake_case to camelCase

### DIFF
--- a/server/zally-core/src/main/resources/reference.conf
+++ b/server/zally-core/src/main/resources/reference.conf
@@ -19,8 +19,7 @@ CaseChecker {
   }
   propertyNames {
     allow: [
-      ${CaseChecker.cases.snake_case},
-      _links
+      ${CaseChecker.cases.camelCase}
     ]
   }
   pathParameterNames {


### PR DESCRIPTION
As part of a discussion regarding property name casing in OpenAPI spec, we have decided to default to camelCase instead of the snake_case enforced by the Zalando guidelines.

This is a fork of Zally, where we will change the default casing to camelCase

https://kompasbank.atlassian.net/browse/BB-2399